### PR TITLE
Login-Fehler ausgeben

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -79,7 +79,7 @@ const routes = [
     path: '/login',
     name: 'Login',
     component: Login,
-    props: route  => ({ error_message: route.query.error_message }),
+    props: route  => ({ errorMessage: route.query.errorMessage }),
     async beforeEnter (to, from, next) {
       await store.dispatch('auth/initAuthentication')
       if (await store.dispatch('auth/isAuthenticated')) next("/admin")
@@ -94,7 +94,7 @@ const routes = [
         await store.dispatch('auth/handleRedirectCallback');
         next('/admin');
       } catch (error) {
-        next({ path: "/login", query: { error_message: error.message } });
+        next({ path: "/login", query: { errorMessage: error.message } });
       }
     }
   }

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="container">
-    <div class="card" v-if="error_message">
+    <div class="card" v-if="errorMessage">
       <div class="card-content error-content">
           <div class="error-title">Fehler</div>
-          <div>{{ error_message }}</div>
+          <div>{{ errorMessage }}</div>
       </div>
     </div>
     <div class="card">
@@ -19,7 +19,7 @@
 
 <script>
 export default {
-  props: ["error_message"],
+  props: ["errorMessage"],
   methods: {
     login () {
       this.$store.dispatch('auth/login');


### PR DESCRIPTION
Bei einem Login-Problem (`handleRedirectCallback` wirft Exception) wird zurück auf die Seite mit Login-Button geleitet, allerdings wird der Text der Meldung mit übergeben und über dem Button angezeigt. Für #10 