### PR TITLE
Fehler-Checks, Ausgabe via Toasts statt alert()

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -20,6 +20,7 @@ function errorToast(message) {
 }
 
 function isResultValid(resData, messagePrefix) {
+  if (!resData) return false;
   if (resData.errors) {
     resData.errors.forEach(error => errorToast(messagePrefix + ': ' + error.message));
     return false;


### PR DESCRIPTION
Queries werden mitunter keine Exceptions geben aber einen Fehlerstatus zurück.