### PR TITLE
Letzten Tag in fillTrainings mitnehmen

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -541,7 +541,7 @@ export default new Vuex.Store({
 
       if (d < startDate) d = d.add(7, 'day');
       
-      while (d < endDate) {
+      while (d <= endDate) {
         let dateFormatted = d.format('YYYY-MM-DD')
         let j = course.trainings.findIndex(o => o.trainingDate == dateFormatted)
         if (j == -1) {


### PR DESCRIPTION
Im Alltagsgebrauch sind Zeiträume über mehrere Tage durchaus _einschliesslich_ des letzten Tages ("die Woche geht von Montag bis Sonntag"), insofern ist es nicht falsch zu erwarten dass sich Trainings genauso verhalten.
Und es macht Auto-Füllen bei Ein-Tages-Trainings möglich.