### PR TITLE
Tweaks für überschriebene Trainingszeiten

### DIFF
--- a/src/components/CalendarEntry.vue
+++ b/src/components/CalendarEntry.vue
@@ -12,8 +12,7 @@
       {{ data.trainingDate | dayjs("dateshort") }} {{ data.course.titleShort }}
     </div>
     <div>
-        <Alt :x="data.course.timeBegin" :y="data.timeBegin" :format="formatTime"/> -
-        <Alt :x="data.course.timeEnd" :y="data.timeEnd" :format="formatTime"/>
+        <TrainingTimeRange :defaultObj="data.course" :altObj="data" />
     </div>
     <div>
         <Alt :x="data.course.location" :y="data.location"/>
@@ -22,11 +21,15 @@
 </template>
 
 <script>
+import TrainingTimeRange from "@/components/TrainingTimeRange"
 import { mapActions } from 'vuex';
 
 export default {
   name: "CalendarEntry",
   props: ["data", "attend", "trainingId"],
+  components: {
+    TrainingTimeRange
+  },
   methods: {
       ...mapActions(["toggleAttendance"])
   },

--- a/src/components/Training.vue
+++ b/src/components/Training.vue
@@ -8,9 +8,7 @@
         <Alt :x="data.course.location" :y="data.location"/>
       </div>
       <div>
-        <Alt :x="data.course.timeBegin" :y="data.timeBegin" :format="formatTime"/>
-         - 
-        <Alt :x="data.course.timeEnd" :y="data.timeEnd" :format="formatTime"/>
+        <TrainingTimeRange :defaultObj="data.course" :altObj="data" />
       </div>
       <div>
         <Alt :x="data.course.comment" :y="data.comment"/>
@@ -46,10 +44,14 @@
 
 <script>
 import _ from 'lodash'
+import TrainingTimeRange from "@/components/TrainingTimeRange"
 
 export default {
   name: "Training",
   props: ["data"],
+  components: {
+    TrainingTimeRange
+  },
   data () {
     return {
       collapseAttending: false,

--- a/src/components/TrainingTimeRange.vue
+++ b/src/components/TrainingTimeRange.vue
@@ -1,8 +1,11 @@
 <template>
   <span>
-    <Alt :x="defaultObj.timeBegin" :y="altObj ? altObj.timeBegin : null" :format="formatTime"/>
-      - 
-    <Alt :x="defaultObj.timeEnd" :y="altObj ? altObj.timeEnd : null" :format="formatTime"/>
+    <span :class="{strike: showAlternative}">
+        {{ formatTime(defaultObj.timeBegin) }} - {{ formatTime(defaultObj.timeEnd) }}
+    </span>
+    <span v-if="showAlternative">
+        {{ formatTime(altObj.timeBegin ? altObj.timeBegin : defaultObj.timeBegin) }} - {{ formatTime(altObj.timeEnd ? altObj.timeEnd : defaultObj.timeEnd) }}
+    </span>
   </span>
 </template>
 
@@ -11,9 +14,19 @@ export default {
   name: "TrainingTimeRange",
   props: ["defaultObj", "altObj"],
   computed: {
+    showAlternative () {
+        console.log(this.altObj, this.altObj.timeBegin, this.altObj.timeEnd)
+        return this.altObj && (this.altObj.timeBegin || this.altObj.timeEnd)
+    },
     formatTime () {
       return function (x) { return this.$options.filters.timejs(x, "HH:mm") }
     }
   },
 };
 </script>
+
+<style scoped>
+.strike {
+    text-decoration: line-through;
+}
+</style>

--- a/src/components/TrainingTimeRange.vue
+++ b/src/components/TrainingTimeRange.vue
@@ -15,7 +15,6 @@ export default {
   props: ["defaultObj", "altObj"],
   computed: {
     showAlternative () {
-        console.log(this.altObj, this.altObj.timeBegin, this.altObj.timeEnd)
         return this.altObj && (this.altObj.timeBegin || this.altObj.timeEnd)
     },
     formatTime () {

--- a/src/components/TrainingTimeRange.vue
+++ b/src/components/TrainingTimeRange.vue
@@ -1,0 +1,19 @@
+<template>
+  <span>
+    <Alt :x="defaultObj.timeBegin" :y="altObj ? altObj.timeBegin : null" :format="formatTime"/>
+      - 
+    <Alt :x="defaultObj.timeEnd" :y="altObj ? altObj.timeEnd : null" :format="formatTime"/>
+  </span>
+</template>
+
+<script>
+export default {
+  name: "TrainingTimeRange",
+  props: ["defaultObj", "altObj"],
+  computed: {
+    formatTime () {
+      return function (x) { return this.$options.filters.timejs(x, "HH:mm") }
+    }
+  },
+};
+</script>


### PR DESCRIPTION
Wird eine Trainingsstart- oder endzeit überschrieben werden jetzt die "alten" Zeiten zusammen durchgestrichen und die neuen zusammen dargestellt. (Siehe Bilder.)

IMO ist damit die "neue" Trainingszeit visuell einfacher zu erfassen.
Nicht nur ändert sich meistens sowieso die Start- _und_ Endzeit (d.h. granular nur das eine, aber nicht das andere durchzustreichen ist womöglich gar nicht so oft nötig), relevanter ist vmtl zu erkennen dass sich die Zeit _irgendwie_ geändert hat, d.h. immer Start- und Endzeit durchzustreichen ist akzeptabel, wenn nicht sogar zu bevorzugen.

Vorher:
![image](https://user-images.githubusercontent.com/4117506/192109350-90a61756-a9c0-44a3-a80e-c5e77756c858.png)

Nachher:
![image](https://user-images.githubusercontent.com/4117506/192109372-a3de51ac-ea97-47b6-bdbc-6d2f33e674c9.png)
